### PR TITLE
Update: Add GitLab pipeline ID support for commits with multiple piplines

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Flags:
   -h, --help                      help for cov
       --host-url string           The host URL of the provider. (default "https://api.github.com")
   -i, --ignore strings            Define patterns to ignore matching files.
+      --pipeline-id string        If set, defines the ID of the pipeline to set the status.
   -p, --provider string           The provider to use for status checks: github, gitlab (default "github")
   -q, --quiet                     Do not print details, just the verdict
       --report-path string        Defines the path for the status report. (default "cov.report")

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/fatih/color v1.13.0
 	github.com/gobwas/glob v0.2.3
+	github.com/google/go-querystring v1.1.0
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.11 // indirect
 	github.com/spf13/cobra v1.1.1

--- a/internal/statuscheck/githubcheck/statuschecker.go
+++ b/internal/statuscheck/githubcheck/statuschecker.go
@@ -45,7 +45,7 @@ func (s *githubStatusCheck) Send(reportPath string, target string, token string)
 }
 
 // Write writes the reports file.
-func (s *githubStatusCheck) Write(path string, coverage int, threshold int) error {
+func (s *githubStatusCheck) Write(path string, coverage float64, threshold float64) error {
 
 	s.Context = "cov"
 	s.State = func() string {
@@ -55,7 +55,7 @@ func (s *githubStatusCheck) Write(path string, coverage int, threshold int) erro
 		return "failure"
 	}()
 	s.Description = func() string {
-		info := fmt.Sprintf("%d%% / %d%%", coverage, threshold)
+		info := fmt.Sprintf("%.2f%% / %.2f%%", coverage, threshold)
 		if coverage >= threshold {
 			return fmt.Sprintf("success %s", info)
 		}

--- a/internal/statuscheck/gitlabcheck/statuschecker.go
+++ b/internal/statuscheck/gitlabcheck/statuschecker.go
@@ -14,12 +14,12 @@ import (
 )
 
 type gitlabStatusCheck struct {
-	Context     string `json:"context" url:"context"`
-	Coverage    int    `json:"coverage" url:"coverage"`
-	Description string `json:"description" url:"description"`
-	PipelineID  string `json:"pipeline_id,omitempty" url:"pipeline_id,omitempty"`
-	State       string `json:"state" url:"state"`
-	TargetURL   string `json:"target_url,omitempty" url:"target_url,omitempty"`
+	Context     string  `json:"context" url:"context"`
+	Coverage    float64 `json:"coverage" url:"coverage"`
+	Description string  `json:"description" url:"description"`
+	PipelineID  string  `json:"pipeline_id,omitempty" url:"pipeline_id,omitempty"`
+	State       string  `json:"state" url:"state"`
+	TargetURL   string  `json:"target_url,omitempty" url:"target_url,omitempty"`
 
 	hostURL string `json:"-" url:"-"`
 }
@@ -50,7 +50,7 @@ func (s *gitlabStatusCheck) Send(reportPath string, target string, token string)
 }
 
 // Write writes the reports file.
-func (s *gitlabStatusCheck) Write(path string, coverage int, threshold int) error {
+func (s *gitlabStatusCheck) Write(path string, coverage float64, threshold float64) error {
 
 	s.Context = "cov"
 	s.Coverage = coverage
@@ -61,7 +61,7 @@ func (s *gitlabStatusCheck) Write(path string, coverage int, threshold int) erro
 		return "failure"
 	}()
 	s.Description = func() string {
-		info := fmt.Sprintf("%d%% / %d%%", coverage, threshold)
+		info := fmt.Sprintf("%.2f%% / %.2f%%", coverage, threshold)
 		if coverage >= threshold {
 			return fmt.Sprintf("success %s", info)
 		}

--- a/internal/statuscheck/gitlabcheck/statuschecker.go
+++ b/internal/statuscheck/gitlabcheck/statuschecker.go
@@ -14,14 +14,14 @@ import (
 )
 
 type gitlabStatusCheck struct {
-	Context     string `url:"context"`
-	Coverage    int    `url:"coverage"`
-	Description string `url:"description"`
-	PipelineID  string `url:"pipeline_id,omitempty"`
-	State       string `url:"state"`
-	TargetURL   string `url:"target_url,omitempty"`
+	Context     string `json:"context" url:"context"`
+	Coverage    int    `json:"coverage" url:"coverage"`
+	Description string `json:"description" url:"description"`
+	PipelineID  string `json:"pipeline_id,omitempty" url:"pipeline_id,omitempty"`
+	State       string `json:"state" url:"state"`
+	TargetURL   string `json:"target_url,omitempty" url:"target_url,omitempty"`
 
-	hostURL string `url:"-"`
+	hostURL string `json:"-" url:"-"`
 }
 
 // New returns a new statuc checker for GitLab.

--- a/internal/statuscheck/gitlabcheck/statuschecker.go
+++ b/internal/statuscheck/gitlabcheck/statuschecker.go
@@ -58,7 +58,7 @@ func (s *gitlabStatusCheck) Write(path string, coverage float64, threshold float
 		if coverage >= threshold {
 			return "success"
 		}
-		return "failure"
+		return "failed"
 	}()
 	s.Description = func() string {
 		info := fmt.Sprintf("%.2f%% / %.2f%%", coverage, threshold)

--- a/internal/statuscheck/gitlabcheck/statuschecker.go
+++ b/internal/statuscheck/gitlabcheck/statuschecker.go
@@ -15,6 +15,7 @@ import (
 
 type gitlabStatusCheck struct {
 	Context     string `url:"context"`
+	Coverage    int    `url:"coverage"`
 	Description string `url:"description"`
 	PipelineID  string `url:"pipeline_id,omitempty"`
 	State       string `url:"state"`
@@ -52,6 +53,7 @@ func (s *gitlabStatusCheck) Send(reportPath string, target string, token string)
 func (s *gitlabStatusCheck) Write(path string, coverage int, threshold int) error {
 
 	s.Context = "cov"
+	s.Coverage = coverage
 	s.State = func() string {
 		if coverage >= threshold {
 			return "success"

--- a/internal/statuscheck/statuscheck.go
+++ b/internal/statuscheck/statuscheck.go
@@ -7,7 +7,7 @@ type StatusChecker interface {
 	Send(reportPath string, target string, token string) error
 
 	// Write creates the reports file.
-	Write(path string, coverage int, threshold int) error
+	Write(path string, coverage float64, threshold float64) error
 
 	// WriteNoop sends a noop check.
 	WriteNoop(path string) error

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ func main() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			branch := viper.GetString("branch")
-			threshold := viper.GetInt("threshold")
+			threshold := viper.GetFloat64("threshold")
 			filters := viper.GetStringSlice("filters")
 			hostURL := viper.GetString("host-url")
 			ignored := viper.GetStringSlice("ignore")
@@ -106,22 +106,22 @@ func main() {
 
 			tree := coverage.NewTree(profiles, files)
 			if !quiet {
-				tree.Fprint(os.Stderr, true, "", float64(threshold))
+				tree.Fprint(os.Stderr, true, "", threshold)
 			}
 
 			coverage := tree.GetCoverage()
-			isSuccess := threshold > 0 && threshold <= int(coverage)
+			isSuccess := threshold > 0 && threshold <= coverage
 
 			if isSuccess {
-				fmt.Printf("up to standard. %.0f%% / %d%%\n", coverage, threshold)
+				fmt.Printf("up to standard. %.2f%% / %.2f%%\n", coverage, threshold)
 			} else if threshold > 0 {
-				fmt.Printf("not up to standard. %.0f%% / %d%%\n", coverage, threshold)
+				fmt.Printf("not up to standard. %.2f%% / %.2f%%\n", coverage, threshold)
 			} else {
-				fmt.Printf("%.0f%% / %d%%\n", coverage, threshold)
+				fmt.Printf("%.2f%% / %.2f%%\n", coverage, threshold)
 			}
 
 			if writeReport != "" {
-				if err := statusChecker.Write(reportPath, int(coverage), threshold); err != nil {
+				if err := statusChecker.Write(reportPath, coverage, threshold); err != nil {
 					return fmt.Errorf("unable to write status check: %w", err)
 				}
 			}
@@ -136,7 +136,7 @@ func main() {
 
 	rootCmd.PersistentFlags().Bool("version", false, "show version")
 	rootCmd.Flags().StringP("branch", "b", "", "The branch to use to check the patch coverage against. Example: master")
-	rootCmd.Flags().IntP("threshold", "t", 0, "The target of coverage in percent that is requested")
+	rootCmd.Flags().Float64P("threshold", "t", 0, "The target of coverage in percent that is requested")
 	rootCmd.Flags().StringSliceP("filter", "f", nil, "The filters to use for coverage lookup")
 	rootCmd.Flags().StringSliceP("ignore", "i", nil, "Define patterns to ignore matching files.")
 	rootCmd.Flags().StringP("provider", "p", "github", "The provider to use for status checks: github, gitlab")

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ func main() {
 			filters := viper.GetStringSlice("filters")
 			hostURL := viper.GetString("host-url")
 			ignored := viper.GetStringSlice("ignore")
+			pipelineID := viper.GetString("pipeline-id")
 			provider := viper.GetString("provider")
 			quiet := viper.GetBool("quiet")
 			targetURL := viper.GetString("target-url")
@@ -57,7 +58,7 @@ func main() {
 			case "github":
 				statusChecker = githubcheck.New(hostURL, targetURL)
 			case "gitlab":
-				statusChecker = gitlabcheck.New(hostURL, targetURL)
+				statusChecker = gitlabcheck.New(hostURL, targetURL, pipelineID)
 			default:
 				return fmt.Errorf("unknown provider: %s", provider)
 			}
@@ -143,6 +144,7 @@ func main() {
 	rootCmd.Flags().IntP("threshold-exit-code", "e", 1, "Set the exit code on coverage threshold miss")
 
 	rootCmd.Flags().String("host-url", "https://api.github.com", "The host URL of the provider.")
+	rootCmd.Flags().String("pipeline-id", "", "If set, defines the ID of the pipeline to set the status.")
 	rootCmd.Flags().String("report-path", "cov.report", "Defines the path for the status report.")
 	rootCmd.Flags().String("target-url", "", "If set, associate the target URL with the status.")
 	rootCmd.Flags().Bool("write-report", false, "If set, write a status check report into --report-path")


### PR DESCRIPTION
#### Description
GitLab can have multiple pipelines ran on a single commit causing the cov status check location to be inconsistent (become detached from its run or placed into its own grouping).

Now, a user can specify the ID of the pipeline through `--pipeline-id` which will tell GitLab which pipeline to set the status to, keeping everything grouped up nicely.

Also, converted coverage numbers to two decimal places as this is supported by GitLab metrics.