### PR TITLE
Update: Ignore test file changes as they are not covered

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -25,9 +25,15 @@ func GetDiffFiles(branch string) (files []string, err error) {
 
 	var goFiles []string
 	for _, f := range files {
-		if strings.HasSuffix(f, ".go") {
-			goFiles = append(goFiles, f)
+		if !strings.HasSuffix(f, ".go") {
+			continue
 		}
+
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+
+		goFiles = append(goFiles, f)
 	}
 
 	return goFiles, nil


### PR DESCRIPTION
#### Description
When an MR only touches golang test files, `cov` will still consider the test files when checking coverage. The problem is test files won't have coverage, so the check will always fail with 0% coverage like these two MRs currently:
- https://github.com/PaloAltoNetworks/bahamut/pull/180
- https://github.com/PaloAltoNetworks/manipulate/pull/177

This change filters out test files when doing a diff so that MRs like the above can pass due to no code changes to non-test code.