### PR TITLE
Update upload-artifact action to version 4

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -84,7 +84,7 @@ runs:
           -t ${{inputs.cov_threshold}} \
           ${{inputs.cov_file}}
 
-  - uses: actions/upload-artifact@v3
+  - uses: actions/upload-artifact@v4
     if: inputs.cov_mode == 'coverage'
     with:
       name: cov.report


### PR DESCRIPTION
## Description

Updated `upload-artifact` to v4, as version 3 got deprecated as of January 30th, 2025, and is causing pipelines to fail now.

## Motivation and Context

Change is required because the older version of the action got deprecated and is breaking pipelines now, and it's also reported under issue #8 

## How Has This Been Tested?

I have updated the same action in multiple pipelines to fix the issue, as it was instructed in the [deprecation notice](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) 

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
